### PR TITLE
Update playbook.yml

### DIFF
--- a/playbook.yml
+++ b/playbook.yml
@@ -228,6 +228,7 @@
 
   - name: Add Adguard IPv6 as resolver for localhost
     when: ansible_default_ipv6.address | length > 0
+    ignore_errors: yes
     lineinfile:
       dest: /etc/resolvconf/resolv.conf.d/head
       line: 'nameserver {{ ansible_default_ipv6.address }}'

--- a/playbook.yml
+++ b/playbook.yml
@@ -241,6 +241,7 @@
 # If you have a better method that sticks after a reboot, please open a PR. Thanks!
   - name: Quick and Dirty way to make sure ip6table rules stick after reboot
     when: ansible_default_ipv6.address | length > 0
+    ignore_errors: yes
     include_role:
        name: oefenweb.rc_local
        apply:
@@ -252,6 +253,7 @@
 
   - name: Make sure DNS resolver sticks after reboot
     when: ansible_default_ipv6.address | length == 0
+    ignore_errors: yes
     include_role:
        name: oefenweb.rc_local
        apply:

--- a/playbook.yml
+++ b/playbook.yml
@@ -86,6 +86,7 @@
 
   - name: Prepare Docker for IPv6
     when: ansible_default_ipv6.address | length > 0
+    ignore_errors: yes
     blockinfile:
       path: /etc/docker/daemon.json
       marker: ""


### PR DESCRIPTION
I found out that ignoring the ip6 check fail allows the rest of the playbook to run.

adding this like in the task where ipv6 check is done helps
`ignore_errors: yes`

if u think it is reasonable then you can pull this change to your master