### PR TITLE
Update middlewares.yml

### DIFF
--- a/roles/docker/files/middlewares.yml
+++ b/roles/docker/files/middlewares.yml
@@ -34,8 +34,8 @@ http:
         average: 100
         burst: 50
 
-    middlewares-ipwhitelist:
-      ipWhiteList:
+    middlewares-ipallowlist:
+      ipAllowList:
         sourceRange:
           - 172.27.0.0/12
 


### PR DESCRIPTION
WRN Middleware "middlewares-ipwhitelist@file" of type IPWhiteList is deprecated, please use IPAllowList instead.